### PR TITLE
feat: Autosave in editor, and warn when leaving without saving

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -27,25 +27,18 @@ import topbar from "../vendor/topbar";
 import Alpine from "alpinejs";
 import intersect from "@alpinejs/intersect";
 import collapse from "@alpinejs/collapse";
-import easyMDE from "easymde";
-
-let nowSeconds = () => Math.round(Date.now() / 1000);
+import AudioPlayer from "./audio";
+import RichText from "./editor";
 
 window.Alpine = Alpine;
 Alpine.plugin(intersect);
 Alpine.plugin(collapse);
 Alpine.start();
 
-const initEasyMDE = (element) =>
-  new easyMDE({
-    element: element,
-    forceSync: true,
-    status: false,
-    spellChecker: false,
-    minHeight: "120px",
-  });
-
-let Hooks = {};
+let Hooks = {
+  AudioPlayer,
+  RichText,
+};
 
 Hooks.Flash = {
   mounted() {
@@ -60,181 +53,6 @@ Hooks.Flash = {
   },
   destroyed() {
     clearTimeout(this.timer);
-  },
-};
-
-Hooks.RichText = {
-  mounted() {
-    // The textarea should be (the first) child of the form with the hook
-    let textArea = initEasyMDE(this.el.querySelector("textarea"));
-
-    this.handleEvent("set_richtext_data", (richtext_data) => {
-      if (
-        richtext_data.id === this.el.id &&
-        richtext_data.richtext_data !== textArea.value()
-      ) {
-        textArea.value(richtext_data.richtext_data);
-      }
-    });
-
-    textArea.codemirror.on("change", () => {
-      this.pushEventTo(this.el, "richtext_updated", {
-        richtext_data: textArea.value(),
-      });
-    });
-  },
-};
-
-Hooks.AudioPlayer = {
-  destroyed() {
-    clearInterval(this.progressTimer);
-    clearTimeout(this.nextTimer);
-    this.player.pause();
-  },
-
-  mounted() {
-    this.player = this.el.querySelector("audio");
-    this.duration = this.el.querySelector("#audio-duration");
-    this.currentTime = this.el.querySelector("#audio-time");
-    this.progressBar = this.el.querySelector("#audio-progress");
-    this.lines = this.el.querySelector("#song-lines").children;
-    this.timings = [];
-
-    let enableAudio = () => {
-      if (this.player.src) {
-        if (this.player.readyState === 0) {
-          document.removeEventListener("click", enableAudio);
-        }
-      }
-    };
-    document.addEventListener("click", enableAudio);
-    this.el.addEventListener("js:listen_now", () => {});
-
-    this.handleEvent("load", ({ url, timings }) => {
-      formatted = timings.map((timing) => timing / 1000);
-      this.player.src = url;
-      this.timings = formatted;
-
-      this.player.addEventListener("loadedmetadata", () => {
-        this.duration = this.el.querySelector("#audio-duration");
-        this.currentTime = this.el.querySelector("#audio-time");
-        this.progressBar = this.el.querySelector("#audio-progress");
-        this.duration.innerText = this.formatTime(this.player.duration);
-        this.currentTime.innerText = this.formatTime(this.player.currentTime);
-        this.pushEventTo(this.el, "loaded");
-        this.stop();
-      });
-    });
-
-    this.el.addEventListener("js:play_pause", () => {
-      if (this.player.paused) {
-        this.play();
-      } else {
-        this.pause();
-      }
-    });
-
-    this.handleEvent("jump", ({ line }) => {
-      time = this.timings[line];
-      this.player.currentTime = this.timings[line];
-
-      this.reformatLines(line);
-      this.updateProgress();
-    });
-
-    this.handleEvent("pause", () => this.pause());
-    this.handleEvent("stop", () => this.stop());
-
-    // Press l to log the current time in player, useful for creating timings
-    this.debugTimings = [];
-    this.el.addEventListener("keydown", (event) => {
-      if (event.keyCode === 76) {
-        // l
-        event.preventDefault();
-        this.debugTimings.push(parseInt(this.player.currentTime * 1000));
-        console.log(this.debugTimings);
-      }
-    });
-  },
-
-  clearNextTimer() {
-    clearTimeout(this.nextTimer);
-    this.nextTimer = null;
-  },
-
-  play() {
-    this.clearNextTimer();
-    this.player.play().then(() => {
-      this.progressTimer = setInterval(() => this.updateProgress(), 100);
-    });
-  },
-
-  pause() {
-    clearInterval(this.progressTimer);
-    this.player.pause();
-  },
-
-  stop() {
-    clearInterval(this.progressTimer);
-    this.player.pause();
-    this.updateProgress();
-  },
-
-  updateProgress() {
-    if (isNaN(this.player.duration)) {
-      return false;
-    }
-    if (!this.nextTimer && this.player.currentTime >= this.player.duration) {
-      clearInterval(this.progressTimer);
-      this.player.pause();
-      this.pushEventTo(this.el, "js_paused");
-      return;
-    }
-
-    currentLineIndex = this.timings.findLastIndex(
-      (timing) => this.player.currentTime > timing - 0.2
-    );
-
-    if (currentLineIndex > -1) {
-      if (currentLineIndex > 0) {
-        this.lines[currentLineIndex - 1].classList.remove(
-          "font-bold",
-          "text-black"
-        );
-        this.lines[currentLineIndex - 1].classList.add("text-gray-600");
-      }
-      this.lines[currentLineIndex].classList.add("font-bold", "text-black");
-      this.lines[currentLineIndex].classList.remove("text-gray-600");
-      //this.lines[currentLineIndex].scrollIntoView({ behavior: "smooth", block: "center" });
-    }
-
-    this.progressBar.style.width = `${
-      (this.player.currentTime / this.player.duration) * 100
-    }%`;
-    this.duration.innerText = this.formatTime(this.player.duration);
-    this.currentTime.innerText = this.formatTime(this.player.currentTime);
-  },
-
-  formatTime(seconds) {
-    return new Date(1000 * seconds).toISOString().substr(14, 5);
-  },
-
-  reformatLines(line) {
-    for (let i = 0; i < this.lines.length; i++) {
-      if (i < line) {
-        this.lines[i].classList.add("text-gray-600");
-        this.lines[i].classList.remove("text-bold", "text-black");
-      } else if (i === line) {
-        this.lines[i].classList.add("text-black", "text-bold");
-        this.lines[i].classList.remove("text-gray-600");
-      } else {
-        this.lines[i].classList.remove(
-          "text-black",
-          "text-bold",
-          "text-gray-600"
-        );
-      }
-    }
   },
 };
 

--- a/assets/js/audio.js
+++ b/assets/js/audio.js
@@ -1,0 +1,154 @@
+AudioPlayer = {
+  destroyed() {
+    clearInterval(this.progressTimer);
+    clearTimeout(this.nextTimer);
+    this.player.pause();
+  },
+
+  mounted() {
+    this.player = this.el.querySelector("audio");
+    this.duration = this.el.querySelector("#audio-duration");
+    this.currentTime = this.el.querySelector("#audio-time");
+    this.progressBar = this.el.querySelector("#audio-progress");
+    this.lines = this.el.querySelector("#song-lines").children;
+    this.timings = [];
+
+    let enableAudio = () => {
+      if (this.player.src) {
+        if (this.player.readyState === 0) {
+          document.removeEventListener("click", enableAudio);
+        }
+      }
+    };
+    document.addEventListener("click", enableAudio);
+    this.el.addEventListener("js:listen_now", () => {});
+
+    this.handleEvent("load", ({ url, timings }) => {
+      formatted = timings.map((timing) => timing / 1000);
+      this.player.src = url;
+      this.timings = formatted;
+
+      this.player.addEventListener("loadedmetadata", () => {
+        this.duration = this.el.querySelector("#audio-duration");
+        this.currentTime = this.el.querySelector("#audio-time");
+        this.progressBar = this.el.querySelector("#audio-progress");
+        this.duration.innerText = this.formatTime(this.player.duration);
+        this.currentTime.innerText = this.formatTime(this.player.currentTime);
+        this.pushEventTo(this.el, "loaded");
+        this.stop();
+      });
+    });
+
+    this.el.addEventListener("js:play_pause", () => {
+      if (this.player.paused) {
+        this.play();
+      } else {
+        this.pause();
+      }
+    });
+
+    this.handleEvent("jump", ({ line }) => {
+      time = this.timings[line];
+      this.player.currentTime = this.timings[line];
+
+      this.reformatLines(line);
+      this.updateProgress();
+    });
+
+    this.handleEvent("pause", () => this.pause());
+    this.handleEvent("stop", () => this.stop());
+
+    // Press l to log the current time in player, useful for creating timings
+    this.debugTimings = [];
+    this.el.addEventListener("keydown", (event) => {
+      if (event.keyCode === 76) {
+        // l
+        event.preventDefault();
+        this.debugTimings.push(parseInt(this.player.currentTime * 1000));
+        console.log(this.debugTimings);
+      }
+    });
+  },
+
+  clearNextTimer() {
+    clearTimeout(this.nextTimer);
+    this.nextTimer = null;
+  },
+
+  play() {
+    this.clearNextTimer();
+    this.player.play().then(() => {
+      this.progressTimer = setInterval(() => this.updateProgress(), 100);
+    });
+  },
+
+  pause() {
+    clearInterval(this.progressTimer);
+    this.player.pause();
+  },
+
+  stop() {
+    clearInterval(this.progressTimer);
+    this.player.pause();
+    this.updateProgress();
+  },
+
+  updateProgress() {
+    if (isNaN(this.player.duration)) {
+      return false;
+    }
+    if (!this.nextTimer && this.player.currentTime >= this.player.duration) {
+      clearInterval(this.progressTimer);
+      this.player.pause();
+      this.pushEventTo(this.el, "js_paused");
+      return;
+    }
+
+    currentLineIndex = this.timings.findLastIndex(
+      (timing) => this.player.currentTime > timing - 0.2
+    );
+
+    if (currentLineIndex > -1) {
+      if (currentLineIndex > 0) {
+        this.lines[currentLineIndex - 1].classList.remove(
+          "font-bold",
+          "text-black"
+        );
+        this.lines[currentLineIndex - 1].classList.add("text-gray-600");
+      }
+      this.lines[currentLineIndex].classList.add("font-bold", "text-black");
+      this.lines[currentLineIndex].classList.remove("text-gray-600");
+      //this.lines[currentLineIndex].scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+
+    this.progressBar.style.width = `${
+      (this.player.currentTime / this.player.duration) * 100
+    }%`;
+    this.duration.innerText = this.formatTime(this.player.duration);
+    this.currentTime.innerText = this.formatTime(this.player.currentTime);
+  },
+
+  formatTime(seconds) {
+    return new Date(1000 * seconds).toISOString().substr(14, 5);
+  },
+
+  reformatLines(line) {
+    for (let i = 0; i < this.lines.length; i++) {
+      if (i < line) {
+        this.lines[i].classList.add("text-gray-600");
+        this.lines[i].classList.remove("text-bold", "text-black");
+      } else if (i === line) {
+        this.lines[i].classList.add("text-black", "text-bold");
+        this.lines[i].classList.remove("text-gray-600");
+      } else {
+        this.lines[i].classList.remove(
+          "text-black",
+          "text-bold",
+          "text-gray-600"
+        );
+      }
+    }
+  },
+};
+
+export default AudioPlayer;

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -1,0 +1,65 @@
+import easyMDE from "easymde";
+
+const initEasyMDE = (element, id) =>
+  new easyMDE({
+    element: element,
+    forceSync: true,
+    status: false,
+    spellChecker: false,
+    minHeight: "120px",
+    autosave: {
+        enabled: true,
+        uniqueId: id,
+        delay: 1000,
+    }
+  });
+
+
+
+RichText = {
+  mounted() {
+    // The textarea should be (the first) child of the form with the hook
+
+    let textElem = this.el.querySelector("textarea");
+    let textArea = initEasyMDE(textElem, this.el.id);
+
+    this.beforeUnload = (e) => {
+        if (this.el.dataset.changed === 'true') {
+            e.preventDefault()
+            e.returnValue = ''
+          }
+    }
+
+    this.jsListener = ({detail}) => {
+      document.querySelectorAll(detail.to).forEach(el => {
+          liveSocket.execJS(el, el.getAttribute(detail.attr))
+      })
+    }
+
+    area = this.el.querySelector("textarea")
+    window.addEventListener('beforeunload', this.beforeUnload, true)
+    window.addEventListener("phx:js-exec", this.jsListener)
+
+    this.handleEvent("set_richtext_data", (richtext_data) => {
+      if (
+        richtext_data.id === this.el.id &&
+        richtext_data.richtext_data !== textArea.value()
+      ) {
+        textArea.value(richtext_data.richtext_data);
+      }
+    });
+
+    textArea.codemirror.on("change", () => {
+      this.pushEventTo(this.el, "richtext_updated", {
+        richtext_data: textArea.value(),
+      });
+    });
+  },
+
+  destroyed() {
+    window.removeEventListener("beforeunload", this.beforeUnload, true);
+    window.removeEventListener("phx:js-exec", this.jsListener);
+  }
+};
+
+export default RichText;

--- a/lib/haj_web.ex
+++ b/lib/haj_web.ex
@@ -23,8 +23,7 @@ defmodule HajWeb do
     quote do
       use Phoenix.Controller,
         namespace: HajWeb,
-        formats: [:html, :json],
-        layouts: [html: HajWeb.Layouts]
+        formats: [:html, :json]
 
       import Plug.Conn
       import HajWeb.Gettext

--- a/lib/haj_web/components/core_components.ex
+++ b/lib/haj_web/components/core_components.ex
@@ -38,6 +38,7 @@ defmodule HajWeb.CoreComponents do
   attr :show, :boolean, default: false
   attr :on_cancel, JS, default: %JS{}
   attr :on_confirm, JS, default: %JS{}
+  attr :data_confirm, :string, default: ""
 
   slot :inner_block, required: true
   slot :title
@@ -75,6 +76,7 @@ defmodule HajWeb.CoreComponents do
               <div class="absolute top-6 right-5">
                 <button
                   phx-click={hide_modal(@on_cancel, @id)}
+                  data-confirm={@data_confirm}
                   type="button"
                   class="-m-3 flex-none p-3 opacity-20 hover:opacity-40"
                   aria-label={gettext("close")}

--- a/lib/haj_web/live/responsibility_live/comment_editor.ex
+++ b/lib/haj_web/live/responsibility_live/comment_editor.ex
@@ -1,10 +1,15 @@
 defmodule HajWeb.ResponsibilityLive.CommentEditor do
   use HajWeb, :live_component
 
+  # Two second debounce of autosave
+  @debounce 2_000
+
+  @impl true
   def mount(socket) do
     {:ok, assign(socket, clientside_rich_text: "")}
   end
 
+  @impl true
   def update(%{comment: comment, action: action} = assigns, socket) do
     rich_text_id =
       case action do
@@ -18,16 +23,84 @@ defmodule HajWeb.ResponsibilityLive.CommentEditor do
      |> assign(changeset: Haj.Responsibilities.change_comment(comment))
      |> assign(:clientside_rich_text, comment.text || "")
      |> assign(:rich_text_id, rich_text_id)
+     |> assign(next_autosave: nil, saved: true)
      |> push_event("set_richtext_data", %{richtext_data: comment.text || "", id: rich_text_id})}
   end
 
+  @impl true
+  def update(%{event: :debounce, data: params}, socket) do
+    # Handle debounce of save, here we autosave the responsibility
+    case socket.assigns.action do
+      :edit ->
+        case Haj.Responsibilities.update_comment(socket.assigns.comment, params) do
+          {:ok, comment} ->
+            send(self(), {:comment_updated, comment})
+            send(self(), :comments_updated)
+
+            {:ok,
+             assign(socket,
+               comment: comment,
+               saved: true,
+               changeset: Haj.Responsibilities.change_comment(comment)
+             )}
+
+          {:error, changeset} ->
+            push_flash(:error, "Error saving comment")
+
+            {:ok, socket |> assign(:changeset, changeset)}
+        end
+
+      :new ->
+        {:ok, socket}
+    end
+  end
+
+  @impl true
   def handle_event("richtext_updated", %{"richtext_data" => richtext_data}, socket) do
+    # If empty, or when cleared, we have sometimes saved
+    saved = if richtext_data == "", do: true, else: false
+
+    send(self(), {:set_saved, saved})
+
     {:noreply,
      socket
-     |> assign(:clientside_rich_text, richtext_data)
+     |> assign(clientside_rich_text: richtext_data, saved: saved)
      |> push_event("richtext_event", %{richtext_data: richtext_data})}
   end
 
+  @impl true
+  def handle_event("validate", %{"comment" => params}, socket) do
+    # This fires whenever the text changes
+    timer =
+      case socket.assigns.next_autosave do
+        nil ->
+          # No previous autosave, we send an message after @debounce time to save the data
+          send_update_after(
+            HajWeb.ResponsibilityLive.CommentEditor,
+            [id: socket.assigns.id, event: :debounce, data: params],
+            @debounce
+          )
+
+        timer ->
+          # Data was changed before save, cancel previous message and send a new one
+          Process.cancel_timer(timer)
+
+          send_update_after(
+            HajWeb.ResponsibilityLive.CommentEditor,
+            [id: socket.assigns.id, event: :debounce, data: params],
+            @debounce
+          )
+      end
+
+    {:noreply,
+     push_event(socket, "js-exec", %{
+       to: "#updated_container",
+       attr: "data-wait"
+     })
+     |> assign(next_autosave: timer)}
+  end
+
+  @impl true
   def handle_event("save", %{"comment" => params}, socket) do
     save_comment(socket, socket.assigns.action, params)
   end
@@ -45,7 +118,8 @@ defmodule HajWeb.ResponsibilityLive.CommentEditor do
 
         {:noreply,
          socket
-         |> push_event("set_richtext_data", %{richtext_data: "", id: socket.assigns.rich_text_id})}
+         |> push_event("set_richtext_data", %{richtext_data: "", id: socket.assigns.rich_text_id})
+         |> assign(saved: true)}
 
       {:error, changeset} ->
         push_flash(:error, "Error saving comment")
@@ -62,6 +136,7 @@ defmodule HajWeb.ResponsibilityLive.CommentEditor do
         {:noreply,
          socket
          |> push_event("set_richtext_data", %{richtext_data: ""})
+         |> assign(saved: true)
          |> push_navigate(to: socket.assigns.navigate)}
 
       {:error, changeset} ->
@@ -71,6 +146,7 @@ defmodule HajWeb.ResponsibilityLive.CommentEditor do
     end
   end
 
+  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -79,10 +155,17 @@ defmodule HajWeb.ResponsibilityLive.CommentEditor do
         for={@changeset}
         phx-target={@myself}
         phx-submit="save"
+        phx-change="validate"
         id="richtext_form"
         class="flex flex-col gap-4"
       >
-        <div phx-hook="RichText" phx-update="ignore" phx-target={@myself} id={@rich_text_id}>
+        <div
+          phx-hook="RichText"
+          data-changed={"#{!@saved}"}
+          phx-update="ignore"
+          phx-target={@myself}
+          id={@rich_text_id}
+        >
           <%= textarea(f, :text, value: @clientside_rich_text) %>
         </div>
         <%= error_tag(f, :text) %>

--- a/lib/haj_web/live/responsibility_live/editor.ex
+++ b/lib/haj_web/live/responsibility_live/editor.ex
@@ -2,21 +2,45 @@ defmodule HajWeb.ResponsibilityLive.Editor do
   use HajWeb, :live_component
   alias Haj.Responsibilities
 
+  # 2 second debounce for autosave
+  @debounce 2_000
+
+  @impl true
   def mount(socket) do
     {:ok, socket}
   end
 
+  @impl true
   def update(%{responsibility: responsibility} = assigns, socket) do
     socket =
-      socket
-      |> assign(assigns)
+      assign(socket, assigns)
       |> assign(:changeset, Responsibilities.change_responsibility(responsibility))
       |> assign(:clientside_rich_text, responsibility.description)
+      |> assign(next_autosave: nil, saved: true)
       |> push_event("set_richtext_data", %{richtext_data: responsibility.description})
 
     {:ok, socket}
   end
 
+  @impl true
+  def update(%{event: :debounce, data: params}, socket) do
+    # Handle debounce of save, here we autosave the responsibility
+    case Haj.Responsibilities.update_responsibility(socket.assigns.responsibility, params) do
+      {:ok, responsibility} ->
+        Process.send(self(), {:responsibility_updated, responsibility}, [])
+
+        {:ok,
+         assign(socket, responsibility: responsibility, saved: true)
+         |> assign(:changeset, Responsibilities.change_responsibility(responsibility))}
+
+      {:error, changeset} ->
+        push_flash(:error, "Error autosaving saving comment")
+
+        {:ok, socket |> assign(:changeset, changeset)}
+    end
+  end
+
+  @impl true
   def handle_event("save", %{"responsibility" => params}, socket) do
     case Haj.Responsibilities.update_responsibility(socket.assigns.responsibility, params) do
       {:ok, _comment} ->
@@ -32,13 +56,48 @@ defmodule HajWeb.ResponsibilityLive.Editor do
     end
   end
 
+  @impl true
+  def handle_event("validate", %{"responsibility" => params}, socket) do
+    # This fires whenever the text changes
+    timer =
+      case socket.assigns.next_autosave do
+        nil ->
+          # No previous autosave, we send an message after @debounce time to save the data
+          send_update_after(
+            HajWeb.ResponsibilityLive.Editor,
+            [id: socket.assigns.id, event: :debounce, data: params],
+            @debounce
+          )
+
+        timer ->
+          # Data was changed before save, cancel previous message and send a new one
+          Process.cancel_timer(timer)
+
+          send_update_after(
+            HajWeb.ResponsibilityLive.Editor,
+            [id: socket.assigns.id, event: :debounce, data: params],
+            @debounce
+          )
+      end
+
+    {:noreply,
+     push_event(socket, "js-exec", %{
+       to: "#updated_container",
+       attr: "data-wait"
+     })
+     |> assign(next_autosave: timer)}
+  end
+
   def handle_event("richtext_updated", %{"richtext_data" => richtext_data}, socket) do
+    send(self(), {:set_saved, false})
+
     {:noreply,
      socket
-     |> assign(:clientside_rich_text, richtext_data)
+     |> assign(clientside_rich_text: richtext_data, saved: false)
      |> push_event("richtext_event", %{richtext_data: richtext_data})}
   end
 
+  @impl true
   def render(assigns) do
     ~H"""
     <div>
@@ -47,10 +106,17 @@ defmodule HajWeb.ResponsibilityLive.Editor do
         for={@changeset}
         phx-target={@myself}
         phx-submit="save"
+        phx-change="validate"
         id="richtext_form"
         class="flex flex-col gap-4"
       >
-        <div phx-hook="RichText" phx-update="ignore" phx-target={@myself} id="comment_richtext">
+        <div
+          phx-hook="RichText"
+          data-changed={"#{!@saved}"}
+          phx-update="ignore"
+          phx-target={@myself}
+          id={"comment_richtext_#{@responsibility.id}"}
+        >
           <%= textarea(f, :description, value: @clientside_rich_text) %>
         </div>
         <%= error_tag(f, :description) %>

--- a/lib/haj_web/live/responsibility_live/show.ex
+++ b/lib/haj_web/live/responsibility_live/show.ex
@@ -34,6 +34,7 @@ defmodule HajWeb.ResponsibilityLive.Show do
     case Policy.authorize(:responsibility_edit, user, responsibility) do
       :ok ->
         socket
+        |> assign(saved: true)
         |> assign(page_title: "Redigera ansvar")
 
       _ ->
@@ -59,6 +60,7 @@ defmodule HajWeb.ResponsibilityLive.Show do
         |> assign(show: show)
         |> assign(comments: Responsibilities.get_comments_for_show(responsibility, show.id))
         |> assign(authorized: true)
+        |> assign(saved: true)
         |> assign(comment: comment)
         |> assign(shows: shows)
 
@@ -158,6 +160,31 @@ defmodule HajWeb.ResponsibilityLive.Show do
      )}
   end
 
+  @impl true
+  def handle_info({:responsibility_updated, responsibility}, socket) do
+    {:noreply,
+     assign(socket, responsibility: responsibility)
+     |> assign(saved: true)
+     |> push_event("js-exec", %{
+       to: "#updated_container",
+       attr: "data-done"
+     })}
+  end
+
+  @impl true
+  def handle_info({:comment_updated, comment}, socket) do
+    {:noreply,
+     assign(socket, comment: comment)
+     |> assign(saved: true)
+     |> push_event("js-exec", %{
+       to: "#updated_container",
+       attr: "data-done"
+     })}
+  end
+
+  @impl true
+  def handle_info({:set_saved, value}, socket), do: {:noreply, assign(socket, saved: value)}
+
   defp redirect_unathorized(socket, navigate) do
     socket
     |> put_flash(:error, "Du är inte ansvarig för detta ansvar och kan inte ändra på det.")
@@ -196,5 +223,15 @@ defmodule HajWeb.ResponsibilityLive.Show do
       </div>
     </section>
     """
+  end
+
+  defp show_saving(js \\ %JS{}) do
+    JS.show(js, to: "#updated_spinner")
+    |> JS.hide(to: "#updated_check")
+  end
+
+  defp hide_saving(js \\ %JS{}) do
+    JS.hide(js, to: "#updated_spinner")
+    |> JS.show(to: "#updated_check", display: "flex")
   end
 end

--- a/lib/haj_web/live/responsibility_live/show.html.heex
+++ b/lib/haj_web/live/responsibility_live/show.html.heex
@@ -4,7 +4,13 @@
 </div>
 
 <div class="relative mx-auto flex flex-row justify-start gap-4 border-b md:max-w-3xl xl:max-w-5xl">
-  <.form :let={f} as={:tab_form} phx-change="select_tab" phx-no-submit class="my-4 xs:hidden">
+  <.form
+    :let={f}
+    as={:tab_form}
+    phx-change="select_tab"
+    phx-no-submit
+    class="my-4 w-full xs:hidden"
+  >
     <%= select(
       f,
       :tab,

--- a/lib/haj_web/live/responsibility_live/show.html.heex
+++ b/lib/haj_web/live/responsibility_live/show.html.heex
@@ -51,7 +51,11 @@
       <div class="mb-4 border-b pt-4 pb-4">
         <div class="flex flex-row items-center justify-between">
           <h2 class="text-burgandy-500 mb-1 text-xl font-bold">Beskrivning</h2>
-          <.link :if={@live_action == :edit} patch={~p"/responsibilities/#{@responsibility}"}>
+          <.link
+            :if={@live_action == :edit}
+            data-confirm={@saved || "Du har osparade ändringar! Vill du verkligen lämna sidan?"}
+            patch={~p"/responsibilities/#{@responsibility}"}
+          >
             <.icon name={:x_mark} mini class="h-5" />
           </.link>
           <.link
@@ -62,9 +66,36 @@
           </.link>
         </div>
         <p class="text-gray-500">Årsöverskridande beskrivning av ansvaret.</p>
-        <p class="text-gray-500">
-          Uppdaterades <%= format_date(@responsibility.updated_at) %>
-        </p>
+        <div id="updated_at" class="inline-flex items-center space-x-2 text-gray-500">
+          <div>
+            Uppdaterades <%= format_date(@responsibility.updated_at) %>
+          </div>
+          <div id="updated_container" data-wait={show_saving()} data-done={hide_saving()}>
+            <svg
+              id="updated_spinner"
+              class="hidden h-3.5 w-3.5 animate-spin"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="black" stroke-width="4">
+              </circle>
+              <path
+                class="opacity-75"
+                fill="black"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              >
+              </path>
+            </svg>
+            <div
+              id="updated_check"
+              class="hidden flex-row items-center gap-1 rounded-lg border px-1 text-sm"
+            >
+              <.icon name={:check_circle} mini class="h-3.5" />
+              <span>Sparad</span>
+            </div>
+          </div>
+        </div>
       </div>
       <div :if={@live_action == :edit} class="max-w-full">
         <.live_component
@@ -133,14 +164,12 @@
                 <%= full_name(comment.user) %>
               </span>
               <span class="text-sm text-gray-500">
-                <%= format_date(comment.inserted_at) %>
+                <%= format_date(comment.updated_at) %>
               </span>
             </div>
           </div>
           <div class="inline-flex gap-1 text-gray-700">
-            <.link navigate={
-              ~p"/responsibilities/#{@responsibility}/comments/#{comment}/edit"
-            }>
+            <.link navigate={~p"/responsibilities/#{@responsibility}/comments/#{comment}/edit"}>
               <.icon name={:pencil_square} mini class="h-5" />
             </.link>
 
@@ -176,10 +205,46 @@
   :if={@live_action in [:edit_comment]}
   id="comment-modal"
   show
+  data_confirm={@saved || "Du har osparade ändringar! Vill du verkligen lämna sidan?"}
   on_cancel={JS.navigate(~p"/responsibilities/#{@responsibility}/comments?show=#{@show}")}
 >
   <:title>
-    Redigera testamente
+    <div>
+      Redigera testamente
+    </div>
+    <div
+      id="updated_at"
+      class="inline-flex items-center space-x-2 text-sm font-normal text-gray-500"
+    >
+      <div>
+        Uppdaterades <%= format_date(@comment.updated_at) %>
+      </div>
+      <div id="updated_container" data-wait={show_saving()} data-done={hide_saving()}>
+        <svg
+          id="updated_spinner"
+          class="hidden h-3.5 w-3.5 animate-spin"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="black" stroke-width="4">
+          </circle>
+          <path
+            class="opacity-75"
+            fill="black"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          >
+          </path>
+        </svg>
+        <div
+          id="updated_check"
+          class="hidden flex-row items-center gap-1 rounded-lg border px-1 text-sm"
+        >
+          <.icon name={:check_circle} mini class="h-3.5" />
+          <span>Sparad</span>
+        </div>
+      </div>
+    </div>
   </:title>
 
   <:subtitle>


### PR DESCRIPTION
From user feedback. Added functionality for the editor for editing responsibilities perform autosave. This is implemented using a debounce, to save whenever a user stops typing, in order to not overwhelm the database.

Also, the site now warns before leaving a page when the user has edited the contents but not saved yet. This does not fire in all cases. For example, it is not possible to easily warn when clicking on a link in the sidebar.