### PR TITLE
fix: add more formatting for application data

### DIFF
--- a/lib/haj_web/live/applications_live.ex
+++ b/lib/haj_web/live/applications_live.ex
@@ -32,6 +32,8 @@ defmodule HajWeb.ApplicationsLive do
   end
 
   def render(assigns) do
+    text_to_html_opts = []
+
     ~H"""
     <div class="border-burgandy-500 mb-2 flex flex-col gap-2 border-b-2 py-2 md:flex-row md:items-center">
       <div class="font-bold uppercase">Filtrera</div>
@@ -89,13 +91,34 @@ defmodule HajWeb.ApplicationsLive do
                 </tr>
                 <tr x-show="show" class={if rem(i, 2) == 0, do: "bg-white", else: "bg-gray-50"}>
                   <td colspan="5" class="w-full gap-2 px-4 py-3">
-                    <div>Tid för ansökan: <%= application.inserted_at %></div>
-                    <div>Övrigt: <%= application.other %></div>
-                    <div>Eventuell rangordning: <%= application.ranking %></div>
+                    <div><b>Tid för ansökan:</b> <%= application.inserted_at %></div>
+                    <hr class="mb-2"/>
+                    <div>
+                      <p><b>Övrigt</b></p>
+                      <%= case application.other do
+                        nil -> ~H"<i>inget svar</i>"
+                        text -> text_to_html(text, text_to_html_opts)
+                      end %>
+                    </div>
+                    <hr class="mb-2"/>
+                    <div>
+                      <p><b>Eventuell rangordning</b></p>
+                      <p>
+                        <%= case application.ranking do
+                          nil -> ~H"<i>inget svar</i>"
+                          text -> text_to_html(text, text_to_html_opts)
+                        end %>
+                      </p>
+                    </div>
                     <%= for asg <- application.application_show_groups do %>
                       <%= if asg.show_group.application_extra_question do %>
+                        <hr class="mb-2"/>
                         <div>
-                          <%= asg.show_group.application_extra_question %>: <%= asg.special_text %>
+                          <p><b> <%= asg.show_group.application_extra_question %> </b></p>
+                          <%= case asg.special_text do
+                            nil -> ~H"<i>inget svar</i>"
+                            text -> text_to_html(text, text_to_html_opts)
+                          end %>
                         </div>
                       <% end %>
                     <% end %>

--- a/lib/haj_web/live/applications_live.ex
+++ b/lib/haj_web/live/applications_live.ex
@@ -32,8 +32,6 @@ defmodule HajWeb.ApplicationsLive do
   end
 
   def render(assigns) do
-    text_to_html_opts = []
-
     ~H"""
     <div class="border-burgandy-500 mb-2 flex flex-col gap-2 border-b-2 py-2 md:flex-row md:items-center">
       <div class="font-bold uppercase">Filtrera</div>

--- a/lib/haj_web/live/applications_live.ex
+++ b/lib/haj_web/live/applications_live.ex
@@ -95,30 +95,31 @@ defmodule HajWeb.ApplicationsLive do
                     <hr class="mb-2"/>
                     <div>
                       <p><b>Övrigt</b></p>
-                      <%= case application.other do
-                        nil -> ~H"<i>inget svar</i>"
-                        text -> text_to_html(text, text_to_html_opts)
-                      end %>
+                      <%= if application.other == nil do %>
+                        <i>Inget svar</i>
+                      <%= else %>
+                        <p class="whitespace-pre-line"> <%= application.other %> </p>
+                      <%= end %>
                     </div>
                     <hr class="mb-2"/>
                     <div>
                       <p><b>Eventuell rangordning</b></p>
-                      <p>
-                        <%= case application.ranking do
-                          nil -> ~H"<i>inget svar</i>"
-                          text -> text_to_html(text, text_to_html_opts)
-                        end %>
-                      </p>
+                      <%= if application.ranking == nil do %>
+                        <i>Inget svar</i>
+                      <%= else %>
+                        <p class="whitespace-pre-line"> <%= application.ranking %> </p>
+                      <%= end %>
                     </div>
                     <%= for asg <- application.application_show_groups do %>
                       <%= if asg.show_group.application_extra_question do %>
                         <hr class="mb-2"/>
                         <div>
                           <p><b> <%= asg.show_group.application_extra_question %> </b></p>
-                          <%= case asg.special_text do
-                            nil -> ~H"<i>inget svar</i>"
-                            text -> text_to_html(text, text_to_html_opts)
-                          end %>
+                          <%= if asg.special_text == nil do %>
+                            <i>Inget svar</i>
+                          <%= else %>
+                            <p class="whitespace-pre-line"> <%= asg.special_text %> </p>
+                          <%= end %>
                         </div>
                       <% end %>
                     <% end %>


### PR DESCRIPTION
This PR does the following:
- preserves newlines in the html output in the application page from the users answers (this was the main goal)
- some additional formatting

it now looks like this:
![2023-09-18-14:36:11](https://github.com/datasektionen/haj/assets/16057417/a93a163f-3418-4a71-affa-a028d61bc806)

`text_to_html` escapes html input from the string it gets as well, so that shouldn't be a concern